### PR TITLE
Prepare for release 3.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	kmodules.xyz/client-go v0.0.0-20210928133955-8df5bb467db6
 	kmodules.xyz/custom-resources v0.0.0-20211007080833-72bd9e8cae6e
 	kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61
-	stash.appscode.dev/apimachinery v0.15.1-0.20211008135320-561988c602a7
+	stash.appscode.dev/apimachinery v0.16.0
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -1062,5 +1062,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-stash.appscode.dev/apimachinery v0.15.1-0.20211008135320-561988c602a7 h1:doYN5+1pGZfUZozj1bKHjzrfSUO/RBlLj1kAxWVucPM=
-stash.appscode.dev/apimachinery v0.15.1-0.20211008135320-561988c602a7/go.mod h1:owQaNhtUMh6s727PX9dGIoLlqblMvMOtYLF2jy9CUek=
+stash.appscode.dev/apimachinery v0.16.0 h1:6mvmPatv9nR5Wc+PCt3Cg9R7WRJRqhy2yLu2b/HmXhA=
+stash.appscode.dev/apimachinery v0.16.0/go.mod h1:unpV/YyHVECNrAdFjFg/SetmPeUjfvc2+P8cnGjih/U=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -590,7 +590,7 @@ sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.15.1-0.20211008135320-561988c602a7
+# stash.appscode.dev/apimachinery v0.16.0
 ## explicit
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.10.11
Release-tracker: https://github.com/stashed/CHANGELOG/pull/41
Signed-off-by: 1gtm <1gtm@appscode.com>